### PR TITLE
Added BERT support for sequence classification

### DIFF
--- a/lib/transformers/models/auto/modeling_auto.rb
+++ b/lib/transformers/models/auto/modeling_auto.rb
@@ -28,6 +28,7 @@ module Transformers
   }
 
   MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING_NAMES = {
+    "bert" => "BertForSequenceClassification",
     "deberta-v2" => "DebertaV2ForSequenceClassification",
     "distilbert" => "DistilBertForSequenceClassification",
     "xlm-roberta" => "XLMRobertaForSequenceClassification"


### PR DESCRIPTION
Tested on Apple M1 Pro

bert_test.rb
```ruby
require 'torch-rb'
require 'transformers-rb'

queries = ["How to install Ruby on Rails?", "rails install guide", "llm bedrock reference"]
model_id = "shahrukhx01/bert-mini-finetune-question-detection"
classifier = Transformers.pipeline("text-classification", model_id, device: "mps")
results = classifier.call(queries)
puts results.inspect
```

Run:
```bash
ruby bert_test.rb
```

Output:
```ruby
[{:label=>"LABEL_1", :score=>0.9997690320014954}, {:label=>"LABEL_0", :score=>0.9995936751365662}, {:label=>"LABEL_0", :score=>0.9990583062171936}]
```