### PR TITLE
Fixes device nil issue with pipelines

### DIFF
--- a/lib/transformers/pipelines/base.rb
+++ b/lib/transformers/pipelines/base.rb
@@ -99,7 +99,7 @@ module Transformers
       modelcard: nil,
       framework: nil,
       task: "",
-      device: nil,
+      device: "cpu",
       **kwargs
     )
       if framework.nil?
@@ -113,6 +113,8 @@ module Transformers
       @image_processor = image_processor
       @modelcard = modelcard
       @framework = framework
+      @device = device
+      @device = Torch::Device.new(device) if device.is_a?(String)
 
       if device.nil?
         if Torch::CUDA.available? || Torch::Backends::MPS.available?

--- a/test/pipeline_test.rb
+++ b/test/pipeline_test.rb
@@ -96,4 +96,13 @@ class PipelineTest < Minitest::Test
     result = fe.("test/support/pipeline-cat-chonk.jpeg")
     assert_in_delta 0.868, result[0][0][0], 0.01
   end
+
+  def test_pipeline_input_works_with_more_than_ten
+    embedding = Transformers.pipeline("embedding")
+    11.times do
+      result = embedding.("Ruby is a programming language created by Matz")
+
+      assert_instance_of(Array, result)
+    end
+  end
 end


### PR DESCRIPTION
This fixes #6.

- Made the default of torch device a cpu for pipelines to specify a device on every pipeline
- Also added the ability to create a pipeline's device as either `String` class or `Torch::Device` class